### PR TITLE
Remove check for explict access/secret key in env

### DIFF
--- a/lib/config.ru
+++ b/lib/config.ru
@@ -13,7 +13,7 @@ def verify_environment_variable_set(var_name)
   end
 end
 
-mandatory_variables = ["CATTLE_URL", "CATTLE_ACCESS_KEY", "CATTLE_SECRET_KEY", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+mandatory_variables = ["CATTLE_URL", "CATTLE_ACCESS_KEY", "CATTLE_SECRET_KEY"]
 mandatory_variables.each { |v| verify_environment_variable_set(v) }
 
 interval_secs = Integer(ENV['REAPER_INTERVAL_SECS']) rescue 30


### PR DESCRIPTION
This allows using an EC2 instance role if configured and fails with a permission error if not configured.